### PR TITLE
Fixed infinite loop when not in debug because of assert

### DIFF
--- a/src/GraylogConnection.cpp
+++ b/src/GraylogConnection.cpp
@@ -307,7 +307,8 @@ void GraylogConnection::SendMessageLoop() {
                 } else {
                     bytesSent += cBytes;
                     if (bytesSent == currentMessage.size() + 1) {
-                        assert(logMessages.try_pop());
+                        bool popResult = logMessages.try_pop();
+                        assert(popResult);
                         SetState(ConStatus::NEW_MESSAGE);
                     }
                 }


### PR DESCRIPTION
The assert statement was not executed causing an infinite loop because try_pop() was never called. This caused messages to be logged continuously.

I don't think any docs have to be updated with this change, but correct me if i'm wrong.