### PR TITLE
Remove cmake_installer conan dependency

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,5 @@
 [requires]
 gtest/3121b20-dm3@ess-dmsc/stable
-cmake_installer/3.10.0@conan/stable
 asio/1.12.0@bincrafters/stable
 jsonformoderncpp/3.1.0@vthiery/stable
 


### PR DESCRIPTION
### Description of work

The cmake_installer dependency is causing a problem on some platforms and we should not need it anyway, we require cmake to be system-installed for our projects. The cmake_installer package is not intended to be used in a `conanfile.txt`, only in the `build_requires` for a recipe.
