### PR TITLE
Improve dependency handling in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ else()
     add_definitions(-D_WIN32_WINNT=0x0A00)
 endif(NOT WIN32)
 
+find_package(ASIO REQUIRED MODULE)
+
 add_subdirectory(src)
 
 option(BUILD_EVERYTHING "Build UnitTests & Console Logger" ON)

--- a/cmake/FindASIO.cmake
+++ b/cmake/FindASIO.cmake
@@ -18,3 +18,14 @@ mark_as_advanced(
   ASIO_ROOT_DIR
   ASIO_INCLUDE_DIR
 )
+
+if(ASIO_FOUND)
+    set(ASIO_INCLUDE_DIRS ${ASIO_INCLUDE_DIR})
+endif()
+
+if(ASIO_FOUND AND NOT TARGET ASIO::ASIO)
+    add_library(ASIO::ASIO INTERFACE IMPORTED)
+    set_target_properties(ASIO::ASIO PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${ASIO_INCLUDE_DIR}"
+            )
+endif()

--- a/cmake/GraylogLoggerConfig.cmake.in
+++ b/cmake/GraylogLoggerConfig.cmake.in
@@ -1,12 +1,7 @@
 get_filename_component(GraylogLogger_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 include(CMakeFindDependencyMacro)
 
-install(FILES
-          FindASIO.cmake
-        DESTINATION
-          lib/cmake/GraylogLogger/cmake
-        )
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake/")
 
 find_dependency(ASIO REQUIRED MODULE)
 find_dependency(Threads REQUIRED)

--- a/cmake/GraylogLoggerConfig.cmake.in
+++ b/cmake/GraylogLoggerConfig.cmake.in
@@ -1,4 +1,4 @@
-get_filename_component(GraylogLogger_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(GraylogLogger_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 include(CMakeFindDependencyMacro)
 
 find_dependency(ASIO REQUIRED MODULE)

--- a/cmake/GraylogLoggerConfig.cmake.in
+++ b/cmake/GraylogLoggerConfig.cmake.in
@@ -1,6 +1,13 @@
 get_filename_component(GraylogLogger_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 include(CMakeFindDependencyMacro)
 
+install(FILES
+          FindASIO.cmake
+        DESTINATION
+          lib/cmake/GraylogLogger/cmake
+        )
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/")
+
 find_dependency(ASIO REQUIRED MODULE)
 find_dependency(Threads REQUIRED)
 find_dependency(nlohmann_json REQUIRED)

--- a/cmake/GraylogLoggerConfig.cmake.in
+++ b/cmake/GraylogLoggerConfig.cmake.in
@@ -3,9 +3,7 @@ include(CMakeFindDependencyMacro)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake/")
 
-find_dependency(ASIO REQUIRED MODULE)
 find_dependency(Threads REQUIRED)
-find_dependency(nlohmann_json REQUIRED)
 
 if(NOT TARGET GraylogLogger::graylog_logger)
     include("${GraylogLogger_CMAKE_DIR}/GraylogLoggerTargets.cmake")

--- a/cmake/GraylogLoggerConfig.cmake.in
+++ b/cmake/GraylogLoggerConfig.cmake.in
@@ -1,6 +1,10 @@
 get_filename_component(GraylogLogger_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
 
+find_dependency(ASIO REQUIRED MODULE)
+find_dependency(Threads REQUIRED)
+find_dependency(nlohmann_json REQUIRED)
+
 if(NOT TARGET GraylogLogger::graylog_logger)
     include("${GraylogLogger_CMAKE_DIR}/GraylogLoggerTargets.cmake")
 endif()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,7 +4,7 @@ asio/1.13.0@bincrafters/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 
 [options]
-gtest:shared=True
+gtest:shared=False
 
 [generators]
 cmake

--- a/include/graylog_logger/ConnectionStatus.hpp
+++ b/include/graylog_logger/ConnectionStatus.hpp
@@ -1,0 +1,18 @@
+/* Copyright (C) 2019 European Spallation Source, ERIC. See LICENSE file */
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// \brief Graylog connection status.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+namespace Log {
+enum class Status {
+  ADDR_LOOKUP,
+  ADDR_RETRY_WAIT,
+  CONNECT,
+  SEND_LOOP,
+};
+} // namespace Log

--- a/include/graylog_logger/GraylogInterface.hpp
+++ b/include/graylog_logger/GraylogInterface.hpp
@@ -9,12 +9,25 @@
 
 #pragma once
 
-#include "graylog_logger/GraylogConnection.hpp"
+#include "graylog_logger/ConnectionStatus.hpp"
 #include "graylog_logger/LogUtil.hpp"
 
 namespace Log {
+class GraylogConnection {
+public:
+  using Status = Log::Status;
+  GraylogConnection(std::string Host, int Port);
+  virtual ~GraylogConnection();
+  virtual void sendMessage(std::string Msg);
+  virtual Status getConnectionStatus() const;
+  virtual bool messageQueueEmpty();
+  virtual size_t messageQueueSize();
 
-class GraylogInterface : public BaseLogHandler, private GraylogConnection {
+private:
+  class Impl;
+  std::unique_ptr<Impl> Pimpl;
+};
+class GraylogInterface : public BaseLogHandler, public GraylogConnection {
 public:
   GraylogInterface(const std::string &Host, int Port,
                    size_t MaxQueueLength = 100);
@@ -22,8 +35,6 @@ public:
   void addMessage(const LogMessage &Message) override;
   bool emptyQueue() override;
   size_t queueSize() override;
-  using GraylogConnection::Status;
-  using GraylogConnection::getConnectionStatus;
 
 protected:
   std::string logMsgToJSON(const LogMessage &Message);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,9 +28,9 @@ set(Graylog_INC
 set(common_libs
         PUBLIC
       Threads::Threads
-    PRIVATE
-    nlohmann_json::nlohmann_json
   )
+
+get_target_property(JSON_INCLUDE_DIR nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
 
 add_library(graylog_logger SHARED ${Graylog_SRC} ${Graylog_INC})
 add_library(GraylogLogger::graylog_logger ALIAS graylog_logger)
@@ -42,6 +42,7 @@ target_include_directories(graylog_logger
   PRIVATE
     "."
     ${ASIO_INCLUDE_DIR}
+    ${JSON_INCLUDE_DIR}
 )
 
 add_library(graylog_logger_static STATIC ${Graylog_SRC} ${Graylog_INC} ${Graylog_private_INC})
@@ -54,6 +55,7 @@ target_include_directories(graylog_logger_static
   PRIVATE
     "."
     ${ASIO_INCLUDE_DIR}
+    ${JSON_INCLUDE_DIR}
 )
 
 set_target_properties(graylog_logger PROPERTIES VERSION ${PROJECT_VERSION})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
 find_package(Threads REQUIRED)
+find_package(ASIO REQUIRED MODULE)
+find_package(nlohmann_json REQUIRED)
 
 set(Graylog_SRC
     ConsoleInterface.cpp
@@ -25,9 +27,11 @@ set(Graylog_INC
 )
 
 set(common_libs
+        PUBLIC
         Threads::Threads
-        CONAN_PKG::asio
-        CONAN_PKG::jsonformoderncpp)
+        ASIO::ASIO
+        PRIVATE
+        nlohmann_json::nlohmann_json)
 
 add_library(graylog_logger SHARED ${Graylog_SRC} ${Graylog_INC})
 add_library(GraylogLogger::graylog_logger ALIAS graylog_logger)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,14 +17,14 @@ set(Graylog_INC
     ../include/graylog_logger/ConcurrentQueue.hpp
     ../include/graylog_logger/ConsoleInterface.hpp
     ../include/graylog_logger/FileInterface.hpp
-    ../include/graylog_logger/GraylogConnection.hpp
+    GraylogConnection.hpp
     ../include/graylog_logger/GraylogInterface.hpp
     ../include/graylog_logger/Log.hpp
     ../include/graylog_logger/Logger.hpp
     ../include/graylog_logger/LoggingBase.hpp
     ../include/graylog_logger/LogUtil.hpp
     ../include/graylog_logger/ThreadedExecutor.hpp
-)
+    ../include/graylog_logger/ConnectionStatus.hpp)
 
 set(common_libs
         PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,12 @@ set(Graylog_INC
     ../include/graylog_logger/ThreadedExecutor.hpp
     ../include/graylog_logger/ConnectionStatus.hpp)
     
+set(common_libs
+        PUBLIC
+      Threads::Threads
+    PRIVATE
+    nlohmann_json::nlohmann_json
+  )
 
 add_library(graylog_logger SHARED ${Graylog_SRC} ${Graylog_INC})
 add_library(GraylogLogger::graylog_logger ALIAS graylog_logger)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 find_package(Threads REQUIRED)
-find_package(ASIO REQUIRED MODULE)
 find_package(nlohmann_json REQUIRED)
 
 set(Graylog_SRC
@@ -29,8 +28,8 @@ set(Graylog_INC
 set(common_libs
         PUBLIC
         Threads::Threads
-        ASIO::ASIO
         PRIVATE
+        ASIO::ASIO
         nlohmann_json::nlohmann_json)
 
 add_library(graylog_logger SHARED ${Graylog_SRC} ${Graylog_INC})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,13 +24,7 @@ set(Graylog_INC
     ../include/graylog_logger/LogUtil.hpp
     ../include/graylog_logger/ThreadedExecutor.hpp
     ../include/graylog_logger/ConnectionStatus.hpp)
-
-set(common_libs
-        PUBLIC
-        Threads::Threads
-        PRIVATE
-        ASIO::ASIO
-        nlohmann_json::nlohmann_json)
+    
 
 add_library(graylog_logger SHARED ${Graylog_SRC} ${Graylog_INC})
 add_library(GraylogLogger::graylog_logger ALIAS graylog_logger)
@@ -41,6 +35,7 @@ target_include_directories(graylog_logger
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   PRIVATE
     "."
+    ${ASIO_INCLUDE_DIR}
 )
 
 add_library(graylog_logger_static STATIC ${Graylog_SRC} ${Graylog_INC} ${Graylog_private_INC})
@@ -52,6 +47,7 @@ target_include_directories(graylog_logger_static
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   PRIVATE
     "."
+    ${ASIO_INCLUDE_DIR}
 )
 
 set_target_properties(graylog_logger PROPERTIES VERSION ${PROJECT_VERSION})

--- a/src/GraylogConnection.hpp
+++ b/src/GraylogConnection.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "graylog_logger/ConcurrentQueue.hpp"
+#include "graylog_logger/ConnectionStatus.hpp"
+#include "graylog_logger/GraylogInterface.hpp"
 #include <array>
 #include <asio.hpp>
 #include <atomic>
@@ -24,18 +26,15 @@ struct QueryResult;
 /// \todo Implement timeouts in the ASIO code in case we ever have problems with
 /// bad connections.
 
-class GraylogConnection {
+class GraylogConnection::Impl {
 public:
-  GraylogConnection(std::string Host, int Port);
-  virtual ~GraylogConnection();
-  virtual void sendMessage(std::string msg) { LogMessages.push(msg); };
-  enum class Status {
-    ADDR_LOOKUP,
-    ADDR_RETRY_WAIT,
-    CONNECT,
-    SEND_LOOP,
-  };
+  using Status = Log::Status;
+  Impl(std::string Host, int Port);
+  virtual ~Impl();
+  virtual void sendMessage(std::string Msg) { LogMessages.push(Msg); };
   Status getConnectionStatus() const;
+  bool messageQueueEmpty() { return LogMessages.empty(); }
+  size_t messageQueueSize() { return LogMessages.size(); }
 
 protected:
   enum class ReconnectDelay { LONG, SHORT };

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(unit_tests ${UnitTest_SRC} ${UnitTest_INC})
 target_link_libraries(unit_tests
         GraylogLogger::graylog_logger_static
         CONAN_PKG::jsonformoderncpp
-        CONAN_PKG::gtest)
+        CONAN_PKG::gtest
+        ASIO::ASIO)
         
 add_test(TestAll unit_tests)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(unit_tests ${UnitTest_SRC} ${UnitTest_INC})
 
 target_link_libraries(unit_tests
         GraylogLogger::graylog_logger_static
+        CONAN_PKG::jsonformoderncpp
         CONAN_PKG::gtest)
         
 add_test(TestAll unit_tests)

--- a/unit_tests/QueueLengthTest.cpp
+++ b/unit_tests/QueueLengthTest.cpp
@@ -9,6 +9,7 @@
 #include "graylog_logger/ConsoleInterface.hpp"
 #include "graylog_logger/FileInterface.hpp"
 #include "graylog_logger/GraylogInterface.hpp"
+#include <atomic>
 #include <ciso646>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>


### PR DESCRIPTION
~**merge #32 before this PR**~ done

It turns out using the conan defined cmake targets is convenient for an application but a bad idea for a library. I've changed it to use the modern targets-based approach, but not the ones created by conan. The version of jsonformoderncpp that we are on now defines targets in its own config.cmake, which is the ideal situation.
For asio I've added the target definitions to `FindAsio.cmake`, but it does mean that dependent codebases (for example EFU) would need to update their `FindAsio.cmake` to do the same. If you prefer not to enforce this then I'll change it back to the old approach for asio.

The json library is only used in implementation files so I was able to treat it as a private dependency. The same would be true for asio if PIMPL were used in `GraylogConnection.hpp`, see #30.

